### PR TITLE
fix bug where rotating the screen in a thread will take you back to the ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 [![Build Status](https://travis-ci.org/grzegorznittner/chanu.svg?branch=ui-experimental)](https://travis-ci.org/grzegorznittner/chanu)
 
-4channer - 4chan android app
+Chanu - 4chan android app
 ========
 
 [Design document](https://docs.google.com/document/d/1hYCqC_53iYZ7e13pbmbQ3PTtUat7xwBiH4uzGpat-gM/edit#heading=h.jbxv5gqhprjt)
 
 [4chan API](https://github.com/4chan/4chan-API)
-
-Applications:
-test-app - test application.
 
 ### How to build application
 #### Branch
@@ -17,10 +14,10 @@ test-app - test application.
 #### Terminal
 1.  Set ```ANDROID_HOME``` env variable to your android-sdk folder
 2.  Add ```$ANDROID_HOME/tools``` and ```$ANDROID_HOME/platform-tools``` to the ```PATH```
-3.  Go to application folder, eg. ```$4CHANNER/test-app```
+3.  Go to application folder, eg. ```chanu/app```
 4.  ```ant debug```         <- to build apk file
-5.  ```$ANDROID_HOME/platform-tools/adb.exe -d install -r ./bin/PhotoGrid-debug.apk```     <- installs apk to usb connected device
-6.  ```ant clean```         <- to clean the project
+5.  ```$ANDROID_HOME/platform-tools/adb.exe -d install -r ./bin/4channer-debug.apk```     <- installs apk to usb connected device
+6.  Use ```ant clean```         <- to clean the project
 
 #### Eclipse
 1.  Download [Eclipse ADT](http://developer.android.com/sdk/index.html)

--- a/app/src/com/chanapps/four/activity/BoardActivity.java
+++ b/app/src/com/chanapps/four/activity/BoardActivity.java
@@ -109,7 +109,6 @@ public class BoardActivity extends AbstractDrawerActivity implements ChanIdentif
         if (ChanBoard.isTopBoard(boardCode)) {
             if (DEBUG) Log.i(TAG, "board to board selector, finishing board activity");
             Intent intent = BoardActivity.createIntent(this, boardCode, query);
-            finish();
             startActivity(intent);
         }
         else {
@@ -689,7 +688,7 @@ public class BoardActivity extends AbstractDrawerActivity implements ChanIdentif
                                 scheduleRecreate = false;
                                 recreateListViewPreservingPosition();
                             }
-                            else if (isCurrent && isAlreadyLoaded()) {
+                            if (isCurrent && isAlreadyLoaded()) {
                                 if (DEBUG) Log.i(TAG, "onResume /" + boardCode + "/ q=" + query + " already loaded");
                             }
                             else {

--- a/app/src/com/chanapps/four/activity/ThreadActivity.java
+++ b/app/src/com/chanapps/four/activity/ThreadActivity.java
@@ -1103,16 +1103,13 @@ public class ThreadActivity
         Pair<Integer, ActivityManager.RunningTaskInfo> p = ActivityDispatcher.safeGetRunningTasks(this);
         int numTasks = p.first;
         ActivityManager.RunningTaskInfo task = p.second;
-        if (numTasks == 0
-                || (numTasks == 1
-                && task != null
-                && task.topActivity != null
-                && task.topActivity.getClassName().equals(getClass().getName()))) {
+        if (numTasks == 0 || (numTasks == 1 && task != null && task.topActivity != null && task.topActivity.getClassName().equals(getClass().getName()))) {
             if (DEBUG) Log.i(TAG, "no valid up task found, creating new one");
             Intent intent = BoardActivity.createIntent(getActivityContext(), boardCode, "");
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
         }
+        finish();
     }
 
     @Override

--- a/app/src/com/chanapps/four/activity/ThreadActivity.java
+++ b/app/src/com/chanapps/four/activity/ThreadActivity.java
@@ -252,7 +252,6 @@ public class ThreadActivity
         Intent intent = BoardActivity.createIntent(this, boardCode, "");
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
-        finish();
     }
 
     @Override
@@ -1114,7 +1113,6 @@ public class ThreadActivity
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
         }
-        finish();
     }
 
     @Override
@@ -1172,8 +1170,9 @@ public class ThreadActivity
     @Override
     public void switchBoard(String boardCode, String query) {
         Intent intent = BoardActivity.createIntent(this, boardCode, query);
-        finish();
-        startActivity(intent);
+        if (!this.boardCode.equals(boardCode)) {
+            startActivity(intent);
+        }
     }
 
     protected void switchThreadInternal(String boardCode, long threadNo, long postNo, String query) { // for when we are already in this class

--- a/app/src/com/chanapps/four/fragment/ThreadFragment.java
+++ b/app/src/com/chanapps/four/fragment/ThreadFragment.java
@@ -773,6 +773,8 @@ public class ThreadFragment extends Fragment implements ThreadViewable
             ((ThreadActivity)activity).navigateUp();
         else if (activity instanceof BoardActivity)
             ((BoardActivity)activity).navigateUp();
+        else
+            activity.finish();
     }
 
     protected void setActivityIdToFragment() {

--- a/app/src/com/chanapps/four/fragment/ThreadFragment.java
+++ b/app/src/com/chanapps/four/fragment/ThreadFragment.java
@@ -773,8 +773,6 @@ public class ThreadFragment extends Fragment implements ThreadViewable
             ((ThreadActivity)activity).navigateUp();
         else if (activity instanceof BoardActivity)
             ((BoardActivity)activity).navigateUp();
-        else
-            activity.finish();
     }
 
     protected void setActivityIdToFragment() {


### PR DESCRIPTION
...board page

For some reason screen rotation was causing the switchBoard method to be called in ThreadActivity, which starts a new BoardActivity.  I couldn't figure out why it is calling that but the simple fix is to check if the board you're switching to is already your current board, then no action is required.

There was also an issue when if you rotated the screen on a thread, then picked a new board, the board would not load.  I had to modify the if in BoardActivity in order for it to refresh properly, i'm not sure of the consequences of that.

I also removed some of the finish() calls, I don't know if they're necessary or not but it seems to work without it, and android will end up killing the activity right?
